### PR TITLE
fix: check workspace version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,10 @@ jobs:
 
       - name: Check crate version matches tag
         run: |
-          CARGO_VERSION=$(grep -E "^version" ronky/Cargo.toml | head -1 | cut -d'"' -f2)
+          # Check workspace version since all crates use workspace versioning
+          CARGO_VERSION=$(grep -E "^version" Cargo.toml | head -1 | cut -d'"' -f2)
           if [ "$CARGO_VERSION" != "${{ steps.extract-version.outputs.version }}" ]; then
-            echo "Error: Cargo.toml version ($CARGO_VERSION) doesn't match tag version (${{ steps.extract-version.outputs.version }})"
+            echo "Error: Cargo.toml workspace version ($CARGO_VERSION) doesn't match tag version (${{ steps.extract-version.outputs.version }})"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
The release workflow for v1.1.0 failed because it was checking for the version in `ronky/Cargo.toml`, but that file uses `version.workspace = true` to inherit the version from the workspace root.

## Changes
- Updated the version check in the release workflow to check the workspace root `Cargo.toml` instead of `ronky/Cargo.toml`
- This ensures the workflow correctly validates that the tag version matches the actual workspace version

## Test Plan
- The workflow will now correctly read the version from the workspace root where it's actually defined
- This fix allows the release process to complete successfully for workspace-based versioning