### PR TITLE
fix: use correct CARGO_REGISTRY_TOKEN secret in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,21 @@ jobs:
           draft: false
           prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
 
+      - name: Check CARGO_REGISTRY_TOKEN availability
+        if: ${{ secrets.CARGO_REGISTRY_TOKEN == '' }}
+        run: |
+          echo "::warning::CARGO_REGISTRY_TOKEN secret is not set. Skipping crates.io publication."
+          echo "To enable automatic publishing to crates.io:"
+          echo "1. Get an API token from https://crates.io/settings/tokens"
+          echo "2. Add it as CARGO_REGISTRY_TOKEN in repository Settings → Secrets"
+
       - name: Publish to crates.io
+        if: ${{ secrets.CARGO_REGISTRY_TOKEN != '' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           # Publish in dependency order with retries for crates.io propagation
-          cargo publish -p arri_repr --token ${{ secrets.CARGO_TOKEN }}
+          cargo publish -p arri_repr
 
           # Wait for crates.io to index the package (typically takes 30-60 seconds)
           echo "Waiting for arri_repr to be available on crates.io..."
@@ -66,7 +77,7 @@ jobs:
             sleep 10
           done
 
-          cargo publish -p ronky_derive --token ${{ secrets.CARGO_TOKEN }}
+          cargo publish -p ronky_derive
 
           # Wait for ronky_derive to be indexed
           echo "Waiting for ronky_derive to be available on crates.io..."
@@ -79,6 +90,4 @@ jobs:
             sleep 10
           done
 
-          cargo publish -p ronky --token ${{ secrets.CARGO_TOKEN }}
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+          cargo publish -p ronky

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "test_suite"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "ronky",
  "serde",


### PR DESCRIPTION
## Summary
The release workflow has been failing because it was using the wrong secret name for the crates.io token.

## Problem
- The workflow was trying to use `secrets.CARGO_TOKEN` but the actual secret is named `CARGO_REGISTRY_TOKEN`
- This caused the entire release job to fail even though the GitHub release was created successfully

## Solution
1. **Use correct secret name**: Changed from `CARGO_TOKEN` to `CARGO_REGISTRY_TOKEN`
2. **Use environment variable**: Set `CARGO_REGISTRY_TOKEN` instead of using `--token` flag
3. **Conditional execution**: Only run the publish step if the token is available
4. **Warning message**: Display helpful instructions when the token is missing

## Test Plan
- If CARGO_REGISTRY_TOKEN is not set: Workflow will create GitHub release but skip crates.io publishing with a warning
- If CARGO_REGISTRY_TOKEN is set: Workflow will create GitHub release AND publish to crates.io

The secret should already be configured in the repository (based on the user's comment), so this fix should allow the release workflow to complete successfully.