### PR TITLE
fix: resolve auto release workflow failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,18 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
+      - name: Get token
+        id: get_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RONKY_CD_APP_ID }}
+          private-key: ${{ secrets.RONKY_CD_TOKEN }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - uses: actions/checkout@v5
+        with:
+          token: ${{ steps.get_token.outputs.token }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -48,8 +59,9 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
+          token: ${{ steps.get_token.outputs.token }}
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}


### PR DESCRIPTION
## Summary
- Fixes the auto release workflow that has been failing since the action-gh-release v2 upgrade
- Adds GitHub App token authentication to bypass GitHub Actions recursion prevention
- Updates workflow to use action-gh-release@v2 with proper token configuration

## Root Cause
The issue was GitHub Actions' recursion prevention mechanism. When the version bump workflow (using GitHub App token) pushes a tag, the release workflow using `GITHUB_TOKEN` was blocked from running due to anti-recursion protection.

## Solution  
- Use the same GitHub App token (`ronky-cd`) in both workflows
- Update to action-gh-release@v2 with explicit token parameter
- This allows the release workflow to trigger properly when tags are pushed

## Test Plan
- [x] Verify workflow syntax is valid
- [ ] Test with actual release after merge to main
- [ ] Confirm v1.1.4 release is created properly
- [ ] Verify crates.io publishing still works