### PR TITLE
fix: resolve workflow secrets access error in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,16 +66,8 @@ jobs:
           draft: false
           prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
 
-      - name: Check CARGO_REGISTRY_TOKEN availability
-        if: ${{ secrets.CARGO_REGISTRY_TOKEN == '' }}
-        run: |
-          echo "::warning::CARGO_REGISTRY_TOKEN secret is not set. Skipping crates.io publication."
-          echo "To enable automatic publishing to crates.io:"
-          echo "1. Get an API token from https://crates.io/settings/tokens"
-          echo "2. Add it as CARGO_REGISTRY_TOKEN in repository Settings → Secrets"
-
       - name: Publish to crates.io
-        if: ${{ secrets.CARGO_REGISTRY_TOKEN != '' }}
+        if: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- Remove invalid secrets access in conditional expressions that was causing workflow validation errors
- Simplify condition to check if CARGO_REGISTRY_TOKEN exists using the proper GitHub Actions syntax
- Remove redundant warning step since the CARGO_REGISTRY_TOKEN secret is available

## Test plan
- [ ] Verify workflow validation passes
- [ ] Test release workflow with next version tag

Fixes #172