### PR TITLE
fix: remove conditional secrets access in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,6 @@ jobs:
           prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
 
       - name: Publish to crates.io
-        if: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- Remove `if: ${{ secrets.CARGO_REGISTRY_TOKEN }}` condition that causes workflow validation error
- The condition triggers "Unrecognized named-value: 'secrets'" error in GitHub Actions
- Since CARGO_REGISTRY_TOKEN is configured, the publish step can run unconditionally

## Test plan
- [ ] Verify workflow validation passes
- [ ] Confirm no more secrets access errors

Resolves the remaining workflow validation issue from #172