### PR TITLE
feat: add rename-all feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,17 +145,19 @@ fn main() {
 use ronky::{Exportable, Exported, SCHEMA_VERSION};
 
 /// Metadata about things (and sometimes other things)
+/// Automatically converts snake_case field names to camelCase for the schema
 #[derive(Exported)]
+#[arri(rename_all = "camelCase")] // firstName, lastName, etc. in the schema
 struct About<T: Exportable> {
     /// What we called it before marketing got involved
     #[deprecated(since = "1.0.0", note = "Use `firstName` and `lastName` instead")]
     name: String,
 
     /// The name that appears on your coffee cup at Starbucks
-    first_name: String,
+    first_name: String, // Becomes "firstName" in the schema
 
     /// The name your parents use when you're in trouble
-    last_name: Option<String>,
+    last_name: Option<String>, // Becomes "lastName" in the schema
 
     /// The number that makes you sigh at birthday parties
     age: u32,
@@ -255,10 +257,15 @@ enum Pet {
 
 ### Attribute Options
 
+**Struct-level attributes:**
 - `#[arri(strict)]` - No extra properties allowed
-- `#[arri(transform = "snake_case")]` - Transform enum variant names
-- `#[arri(discriminator = "type")]` - Set discriminator field name
-- `#[arri(rename = "newName")]` - Rename a field or variant
+- `#[arri(rename_all = "camelCase")]` - Transform all field names to a specific case
+  - Supported cases: `camelCase`, `PascalCase`, `snake_case`, `SCREAMING_SNAKE_CASE`, `kebab-case`, `SCREAMING-KEBAB-CASE`
+- `#[arri(transform = "snake_case")]` - Transform enum variant names (enums only)
+- `#[arri(discriminator = "type")]` - Set discriminator field name (tagged unions only)
+
+**Field-level attributes:**
+- `#[arri(rename = "newName")]` - Rename a specific field or variant (overrides `rename_all`)
 - `#[arri(nullable)]` - Mark a field as nullable
 
 ## 🐈 The Ronky Memorial Section

--- a/ronky_derive/src/enum.rs
+++ b/ronky_derive/src/enum.rs
@@ -73,7 +73,7 @@ pub fn export_enum(input: &DeriveInput, variants: &Punctuated<Variant, Comma>) -
                             }
                         });
                     let struct_export: proc_macro2::TokenStream =
-                        export_struct_fields(&fields.named).into();
+                        export_struct_fields(&fields.named, &None).into();
 
                     exported.push(quote! {
                         schema.add_mapping(#variant_name, Box::new({

--- a/test_suite/tests/serialisation.rs
+++ b/test_suite/tests/serialisation.rs
@@ -24,3 +24,166 @@ fn test_rename() {
     let export = export.downcast_ref::<PropertiesSchema>().unwrap();
     assert_eq!(*export, expected);
 }
+
+#[test]
+fn test_rename_all_camel_case() {
+    #[allow(dead_code)]
+    #[derive(Exported)]
+    #[arri(rename_all = "camelCase")]
+    struct Book {
+        id: String,
+        author_name: String,
+        publish_date: String,
+    }
+
+    let export = Book::export();
+    let mut expected = PropertiesSchema::new();
+    expected.set_metadata(MetadataSchema::new().set_id("Book".to_string()).to_owned());
+    expected.set_property("id", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("authorName", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("publishDate", Box::new(TypeSchema::new(Types::String)));
+
+    assert!(export.is::<PropertiesSchema>());
+    let export = export.downcast_ref::<PropertiesSchema>().unwrap();
+    assert_eq!(*export, expected);
+}
+
+#[test]
+fn test_rename_all_pascal_case() {
+    #[allow(dead_code)]
+    #[derive(Exported)]
+    #[arri(rename_all = "PascalCase")]
+    struct Book {
+        id: String,
+        author_name: String,
+        publish_date: String,
+    }
+
+    let export = Book::export();
+    let mut expected = PropertiesSchema::new();
+    expected.set_metadata(MetadataSchema::new().set_id("Book".to_string()).to_owned());
+    expected.set_property("Id", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("AuthorName", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("PublishDate", Box::new(TypeSchema::new(Types::String)));
+
+    assert!(export.is::<PropertiesSchema>());
+    let export = export.downcast_ref::<PropertiesSchema>().unwrap();
+    assert_eq!(*export, expected);
+}
+
+#[test]
+fn test_rename_all_snake_case() {
+    #[allow(dead_code)]
+    #[allow(non_snake_case)]
+    #[derive(Exported)]
+    #[arri(rename_all = "snake_case")]
+    struct Book {
+        id: String,
+        authorName: String,
+        publishDate: String,
+    }
+
+    let export = Book::export();
+    let mut expected = PropertiesSchema::new();
+    expected.set_metadata(MetadataSchema::new().set_id("Book".to_string()).to_owned());
+    expected.set_property("id", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("author_name", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("publish_date", Box::new(TypeSchema::new(Types::String)));
+
+    assert!(export.is::<PropertiesSchema>());
+    let export = export.downcast_ref::<PropertiesSchema>().unwrap();
+    assert_eq!(*export, expected);
+}
+
+#[test]
+fn test_rename_all_screaming_snake_case() {
+    #[allow(dead_code)]
+    #[derive(Exported)]
+    #[arri(rename_all = "SCREAMING_SNAKE_CASE")]
+    struct Book {
+        id: String,
+        author_name: String,
+        publish_date: String,
+    }
+
+    let export = Book::export();
+    let mut expected = PropertiesSchema::new();
+    expected.set_metadata(MetadataSchema::new().set_id("Book".to_string()).to_owned());
+    expected.set_property("ID", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("AUTHOR_NAME", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("PUBLISH_DATE", Box::new(TypeSchema::new(Types::String)));
+
+    assert!(export.is::<PropertiesSchema>());
+    let export = export.downcast_ref::<PropertiesSchema>().unwrap();
+    assert_eq!(*export, expected);
+}
+
+#[test]
+fn test_rename_all_kebab_case() {
+    #[allow(dead_code)]
+    #[derive(Exported)]
+    #[arri(rename_all = "kebab-case")]
+    struct Book {
+        id: String,
+        author_name: String,
+        publish_date: String,
+    }
+
+    let export = Book::export();
+    let mut expected = PropertiesSchema::new();
+    expected.set_metadata(MetadataSchema::new().set_id("Book".to_string()).to_owned());
+    expected.set_property("id", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("author-name", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("publish-date", Box::new(TypeSchema::new(Types::String)));
+
+    assert!(export.is::<PropertiesSchema>());
+    let export = export.downcast_ref::<PropertiesSchema>().unwrap();
+    assert_eq!(*export, expected);
+}
+
+#[test]
+fn test_rename_all_screaming_kebab_case() {
+    #[allow(dead_code)]
+    #[derive(Exported)]
+    #[arri(rename_all = "SCREAMING-KEBAB-CASE")]
+    struct Book {
+        id: String,
+        author_name: String,
+        publish_date: String,
+    }
+
+    let export = Book::export();
+    let mut expected = PropertiesSchema::new();
+    expected.set_metadata(MetadataSchema::new().set_id("Book".to_string()).to_owned());
+    expected.set_property("ID", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("AUTHOR-NAME", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("PUBLISH-DATE", Box::new(TypeSchema::new(Types::String)));
+
+    assert!(export.is::<PropertiesSchema>());
+    let export = export.downcast_ref::<PropertiesSchema>().unwrap();
+    assert_eq!(*export, expected);
+}
+
+#[test]
+fn test_rename_all_with_explicit_rename() {
+    #[allow(dead_code)]
+    #[derive(Exported)]
+    #[arri(rename_all = "camelCase")]
+    struct Book {
+        id: String,
+        #[arri(rename = "customAuthorName")]
+        author_name: String,
+        publish_date: String,
+    }
+
+    let export = Book::export();
+    let mut expected = PropertiesSchema::new();
+    expected.set_metadata(MetadataSchema::new().set_id("Book".to_string()).to_owned());
+    expected.set_property("id", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("customAuthorName", Box::new(TypeSchema::new(Types::String)));
+    expected.set_property("publishDate", Box::new(TypeSchema::new(Types::String)));
+
+    assert!(export.is::<PropertiesSchema>());
+    let export = export.downcast_ref::<PropertiesSchema>().unwrap();
+    assert_eq!(*export, expected);
+}


### PR DESCRIPTION
Resolves https://github.com/Arthurdw/ronky/issues/196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added global field name casing via a rename_all attribute for schema generation (supports camelCase, PascalCase, snake_case, SCREAMING_SNAKE_CASE, kebab-case, SCREAMING-KEBAB-CASE).
  - Respects explicit per-field renames alongside global casing rules.

- Documentation
  - Updated README with guidance and examples for schema naming semantics, including struct-level attributes and rename_all usage.

- Tests
  - Added comprehensive tests validating rename_all transformations and precedence of explicit field renames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->